### PR TITLE
Optimise Everything

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,65 @@
 use std::env;
+use std::io::{self, Write};
+use std::process;
+use std::borrow::Cow;
+
+#[cfg(not(unix))]
+mod platform {
+    use std::ffi::OsString;
+    pub const BUFFER_CAPACITY: usize = 16 * 1024;
+
+    pub fn to_bytes(os_str: OsString) -> Vec<u8> {
+        os_str.into_string().expect("non utf-8 argument only supported on unix").into()
+    }
+}
+
+#[cfg(unix)]
+mod platform {
+    use std::ffi::OsString;
+    pub const BUFFER_CAPACITY: usize = 64 * 1024;
+
+    pub fn to_bytes(os_str: OsString) -> Vec<u8> {
+        use std::os::unix::ffi::OsStringExt;
+        os_str.into_vec()
+    }
+}
+
+use platform::*;
+
+fn fill_up_buffer<'a>(buffer: &'a mut [u8], output: &'a [u8]) -> &'a [u8] {
+    if output.len() > buffer.len() / 2 {
+        return output;
+    }
+
+    let mut buffer_size = output.len();
+    buffer[..buffer_size].clone_from_slice(output);
+
+    while buffer_size < buffer.len() / 2 {
+        let (left, mut right) = buffer.split_at_mut(buffer_size);
+        right[..buffer_size].clone_from_slice(left);
+        buffer_size *= 2;
+    }
+
+    &buffer[..buffer_size]
+}
+
+
+fn write(output: &[u8]) {
+    let stdout = io::stdout();
+    let mut locked = stdout.lock();
+    let mut buffer = [0u8; BUFFER_CAPACITY];
+
+    let filled = fill_up_buffer(&mut buffer, output);
+    while locked.write_all(filled).is_ok() {}
+}
 
 fn main() {
-    let arguments = env::args().collect::<Vec<_>>();
-    
-    match arguments.len() {
-        1 => loop { println!("y") },
-        _ => loop { println!("{}", arguments[1]) },
-    }
+    write(&env::args_os()
+        .nth(1)
+        .map(to_bytes)
+        .map_or(Cow::Borrowed(&b"y\n"[..]), |mut arg| {
+            arg.push(b'\n');
+            Cow::Owned(arg)
+        }));
+    process::exit(1);
 }


### PR DESCRIPTION
Performance is all that matters, Rust is a systems programming language.

This commit implements the following optimisations:
1. Avoid using the `format!` machinery (via `println!` in a tight loop).
2. Avoid allocating a `Vec` of arguments when we just need the second one.
3. Avoid locking `stdout` over and over again in a tight loop, by hoisting
   `stdout.lock()` outside the loop.
4. Use buffered output.

Points 1, 3 and 4 improve overall performance, while point 2 improves start up speed. **Please review carefully.**

This commit increases output throughput as measured by (_short_)

```
target/release/yes | pv > /dev/null
```

and (_long_)

```
target/release/yes aaaaaaaaaaaaaaaa | pv > /dev/null
```

after 20s from:

| Implementation | Throughput (_short_) | Throughput (_long_) |
| --- | --- | --- |
| Old | 3.8 MB/s | 30.2 MB/s |
| New | **4.5 GB/s** | **4.5 GB/s** |
| GNU coreutils 8.21 | 140MB/s | 769MB/s |

This commit also improves error handling by breaking out of the loop on an I/O error.

This PR is also ridiculous.

**EDIT**

I added two new commits with the following additional optimisations:
    1. Do not allocate in the `"y\n"` case by using `Cow` (suggested by @eddyb and @withoutboats)
    2. Use `memcpy`-doubling to write progressively bigger buffers. Starts with a single copy of the output, then two, three etc. up until 64KB (suggested by @Veedrac).

Point (2) in particular increased throughput by an order of magnitude and it has the added advantage that time to first byte is really low compared to a fully-buffered approach.

Thanks everyone for contributing. It is very important to get this sort of thing right or people will never migrate off of C++.

**EDIT the second**

Now we also support non-unicode arguments on Unix!
